### PR TITLE
new reload interval option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,18 +35,20 @@ function getDefaults() {
   return {
     loadPath: '/locales/{{lng}}/{{ns}}.json',
     addPath: 'locales/add/{{lng}}/{{ns}}',
-    allowMultiLoading: false
+    allowMultiLoading: false,
+    reloadInterval: false
   };
 }
 
 var Backend = (function () {
   function Backend(services) {
     var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var allOptions = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
 
     _classCallCheck(this, Backend);
 
     this.options = options;
-    this.init(services, options);
+    this.init(services, options, allOptions);
 
     this.type = 'backend';
   }
@@ -54,10 +56,20 @@ var Backend = (function () {
   _createClass(Backend, [{
     key: 'init',
     value: function init(services) {
+      var _this = this;
+
       var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+      var allOptions = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
 
       this.services = services;
       this.options = _extends({}, getDefaults(), this.options, options);
+      this.allOptions = allOptions;
+
+      if (this.options.reloadInterval) {
+        setInterval(function () {
+          _this.reload();
+        }, this.options.reloadInterval);
+      }
     }
   }, {
     key: 'readMulti',
@@ -96,7 +108,7 @@ var Backend = (function () {
   }, {
     key: 'create',
     value: function create(languages, namespace, key, fallbackValue) {
-      var _this = this;
+      var _this2 = this;
 
       if (typeof languages === 'string') languages = [languages];
 
@@ -104,12 +116,54 @@ var Backend = (function () {
       payload[key] = fallbackValue || '';
 
       languages.forEach(function (lng) {
-        var url = _this.services.interpolator.interpolate(_this.options.addPath, { lng: lng, ns: namespace });
+        var url = _this2.services.interpolator.interpolate(_this2.options.addPath, { lng: lng, ns: namespace });
 
         ajax(url, function (err, data, res) {
           //const statusCode = xhr.status.toString();
           // TODO: if statusCode === 4xx do log
         }, payload);
+      });
+    }
+  }, {
+    key: 'reload',
+    value: function reload() {
+      var _this3 = this;
+
+      var _services = this.services;
+      var backendConnector = _services.backendConnector;
+      var languageUtils = _services.languageUtils;
+      var logger = _services.logger;
+
+      var currentLanguage = backendConnector.language;
+      if (currentLanguage && currentLanguage.toLowerCase() === 'cimode') return; // avoid loading resources for cimode
+
+      var toLoad = [];
+
+      var append = function append(lng) {
+        var lngs = languageUtils.toResolveHierarchy(lng);
+        lngs.forEach(function (l) {
+          if (toLoad.indexOf(l) < 0) toLoad.push(l);
+        });
+      };
+
+      append(currentLanguage);
+
+      if (this.allOptions.preload) {
+        this.allOptions.preload.forEach(function (l) {
+          append(l);
+        });
+      }
+
+      toLoad.forEach(function (lng) {
+        _this3.allOptions.ns.forEach(function (ns) {
+          backendConnector.read(lng, ns, 'read', null, null, function (err, data) {
+            if (err) logger.warn('loading namespace ' + ns + ' for language ' + lng + ' failed', err);
+            if (!err && data) logger.log('loaded namespace ' + ns + ' for language ' + lng, data);
+
+            var langLoaded = !err && data ? data[lng][ns] : data;
+            backendConnector.loaded(lng + '|' + ns, err, langLoaded);
+          });
+        });
       });
     }
   }]);


### PR DESCRIPTION
This PR add the capability of **refreshing** translations once your backend server is started within a time interval.

Usage:

```js
i18next
  .use(middleware.LanguageDetector)
  .use(Backend)
  .init({
    backend: {
      reloadInterval: 10000, // refresh translations every 10 seconds
    },
  });
```

default to `false` so no refresh will take place.

Implementation code has been pretty much ported from https://github.com/locize/i18next-node-locize-backend/blob/master/src/index.js#L53

The only change necessary was on L122 - L123 where i needed to provide the object traversing `lang` and `namespace` otherwise the merge were done wrongly. 